### PR TITLE
slight-fix

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -9,20 +9,25 @@
     color: white;
     align-items: center;
     &__box {
-      font-size: 16px;
+      font-size: 20px;
       display: flex;
       justify-content: space-between;
       width: 100%;
-      &__name{
+      &__name {
         font-weight: bold;
       }
       &__menu{
         display: flex;
+        font-size: 16px;
         &__new-group{
           margin-left:0.3rem;
+          font-size: 20px;
+          color: white;
         }
         &__edit-user{
           margin-left:0.3rem;
+          font-size: 20px;
+          color: white;
         }
       }
     }

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,12 +22,13 @@
     .chat-group-form__field--right
       .chat-group-users
         = f.hidden_field :user_ids, value: current_user.id, multiple: true
-        - @group.users.each do |user|
+        -@group.users.each do |user|
           .chat-group-user.clearfix
             %p.chat-group-user__name
-            = user.name 
-            %a.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn.user-search-remove 削除
-            
+            = user.name
+            -unless user.name == current_user.name
+              %a.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn.user-search-remove 削除
+              = f.hidden_field :user_ids, value: @group.users.ids, multiple: true
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -7,7 +7,7 @@
         %li.chat-side__header__box__menu__new-group
           = link_to new_group_path do
             = fa_icon 'pencil-square-o', class: 'icon'
-        %li.chat-side__header__box__memu__edit-user
+        %li.chat-side__header__box__menu__edit-user
           = link_to edit_user_path(current_user) do
             = fa_icon 'cog', class: 'icon'
   .chat-side__groups

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module ChatSpace
       g.helper false
       g.test_framework false
     end
-
+    config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
   end
 end


### PR DESCRIPTION
①fontawesomeのアイコンが見本の配色た違い視認しづらい。
→　白色に変更し、少しだけアイコンを大きく変更

②グループ作成、編集画面、でログインユーザー自身が削除できてしまう。
→　ログインユーザーのみ削除ボタンを弾くように設定

③グループ編集でメンバーを削除していないにも関わらず、Updateするとメンバーが削除されている
→　既存ユーザーはUpdateしても削除されないように変更

④投稿日時が日本時間になっていない
→　日本時間に変更